### PR TITLE
feat: CAKTOAPP-12 - create style tokens, add 'space-grotesk' font

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"
         }
-      ]
+      ],
+      "expo-font"
     ],
     "experiments": {
       "typedRoutes": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cakto-app",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -15,6 +15,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
+    "@expo-google-fonts/space-grotesk": "^0.2.3",
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/bottom-tabs": "^7.0.0",
     "@react-navigation/native": "^7.0.0",

--- a/styles/theme/border-radius.ts
+++ b/styles/theme/border-radius.ts
@@ -1,0 +1,8 @@
+export const borderRadius = {
+  none: 0,
+  xs: 4,
+  sm: 8,
+  base: 12,
+  md: 16,
+  pill: 900,
+} as const;

--- a/styles/theme/border-width.ts
+++ b/styles/theme/border-width.ts
@@ -1,0 +1,5 @@
+export const borderWidth = {
+  none: 0,
+  hairline: 1,
+  thin: 2,
+} as const;

--- a/styles/theme/color.ts
+++ b/styles/theme/color.ts
@@ -1,0 +1,20 @@
+export const color = {
+  secondary: {
+    normal: "rgba(0, 161, 104, 1)",
+    bright: "rgba(52, 240, 174, 1)",
+  },
+  yellow: {
+    alert: "rgba(255, 204, 51, 1)",
+  },
+  red: {
+    negative: "rgba(255, 53, 65, 1)",
+  },
+  white: {
+    100: "rgba(255, 255, 255, 1)",
+    "064": "rgba(255, 255, 255, 0.64)",
+  },
+  gray: {
+    900: "rgba(19, 22, 26, 1)",
+    "064": "rgba(22, 28, 36, 0.64)",
+  },
+} as const;

--- a/styles/theme/font.ts
+++ b/styles/theme/font.ts
@@ -1,0 +1,31 @@
+const size = {
+  xxxs: 12,
+  xxs: 14,
+  xs: 16,
+  sm: 18,
+  md: 20,
+  lg: 24,
+  xxl: 40,
+} as const;
+
+const family = {
+  light: "SpaceGrotesk_300Light",
+  regular: "SpaceGrotesk_400Regular",
+  medium: "SpaceGrotesk_500Medium",
+  semiBold: "SpaceGrotesk_600SemiBold",
+  bold: "SpaceGrotesk_700Bold",
+} as const;
+
+const weight = {
+  light: 300,
+  regular: 400,
+  medium: 500,
+  semiBold: 600,
+  bold: 700,
+} as const;
+
+export const font = Object.freeze({
+  size,
+  family,
+  weight,
+});

--- a/styles/theme/index.ts
+++ b/styles/theme/index.ts
@@ -1,0 +1,15 @@
+import { color } from "./color";
+import { borderRadius } from "./border-radius";
+import { borderWidth } from "./border-width";
+import { spacing } from "./spacing";
+import { size } from "./size";
+import { font } from "./font";
+
+export const theme = Object.freeze({
+  color,
+  borderRadius,
+  borderWidth,
+  spacing,
+  size,
+  font,
+});

--- a/styles/theme/size.ts
+++ b/styles/theme/size.ts
@@ -1,0 +1,10 @@
+export const size = {
+  nano: 16,
+  xxs: 18,
+  xs: 24,
+  sm: 32,
+  md: 40,
+  lg: 48,
+  xl: 56,
+  full: "100%",
+} as const;

--- a/styles/theme/spacing.ts
+++ b/styles/theme/spacing.ts
@@ -1,0 +1,12 @@
+export const spacing = {
+  quarck: 4,
+  nano: 8,
+  base: 12,
+  xxxs: 16,
+  xxs: 24,
+  xs: 32,
+  sm: 40,
+  md: 48,
+  lg: 56,
+  xl: 64,
+} as const;


### PR DESCRIPTION
**Versão 1.0.1**

- Criado paleta de cores (somente as necessárias até o momento);
- Criado tokens de estilização (spacing, border-radius, border-width, etc...);
- Adicionado lib do expo para utilização da fonte **space-grotesk**.